### PR TITLE
toggle class of run and surf buttons with Stimulus controlers

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,3 +12,9 @@ application.register("map", MapController)
 
 import SportsController from "./sports_controller"
 application.register("sports", SportsController)
+
+import RunFiltersController from "./run_filters_controller"
+application.register("run-filters", RunFiltersController)
+
+import SurfFiltersController from "./surf_filters_controller"
+application.register("surf-filters", SurfFiltersController)

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -8,7 +8,6 @@ export default class extends Controller {
   }
 
   connect() {
-    console.log("Hello Map")
     mapboxgl.accessToken = this.apiKeyValue
 
     this.map = new mapboxgl.Map({

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -8,6 +8,7 @@ export default class extends Controller {
   }
 
   connect() {
+    console.log("Hello Map")
     mapboxgl.accessToken = this.apiKeyValue
 
     this.map = new mapboxgl.Map({

--- a/app/javascript/controllers/run_filters_controller.js
+++ b/app/javascript/controllers/run_filters_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["run"]
+  connect() {
+    console.log("Hello from run toggle 2 controller")
+  }
+
+  filter() {
+    console.log("Test toggle ")
+    this.runTarget.classList.toggle("select")
+  }
+}

--- a/app/javascript/controllers/surf_filters_controller.js
+++ b/app/javascript/controllers/surf_filters_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["surf"]
+  connect() {
+    console.log("Hello from surf toggle controller")
+  }
+
+  filter() {
+    console.log("Test surf toggle")
+    this.surfTarget.classList.toggle("select")
+  }
+}

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -7,8 +7,16 @@
 </div>
 <div class="filters-events">
   <div class="d-flex gap-2">
-    <button class="btn-small run select"><p>Running</p></button>
-    <button class="btn-small surf"><p>Surf</p></button>
+    <button class="btn-small run select"
+            data-controller="run-filters"
+            data-action="click->run-filters#filter"
+            data-run-filters-target="run">
+            <p>Running</p></button>
+    <button class="btn-small surf",
+            data-controller="surf-filters"
+            data-action="click->surf-filters#filter"
+            data-surf-filters-target="surf">
+            <p>Surf</p></button>
   </div>
   <form class="form-difficulty row row-cols-lg-auto g-2 align-items-center m-0">
     <%= form_with url: events_path, method: :get, class: "" do |f| %>


### PR DESCRIPTION
Ajouter les data-controller, data-action, et data-target partout on utilise les boutons run et surf pour toggle leur classe select (ajout ou enlèvement de leur classe select en fonction de si ça y est déjà ou pas): 

 <button class="btn-small run select"
            data-controller="run-filters"
            data-action="click->run-filters#filter"
            data-run-filters-target="run">
            <p>Running</p></button>

    <button class="btn-small surf",
            data-controller="surf-filters"
            data-action="click->surf-filters#filter"
            data-surf-filters-target="surf">
            <p>Surf</p></button>